### PR TITLE
Add support for

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,11 @@ organization := "com.comcast"
 
 name := "actor-service-registry-aggregate"
 
-version := "1.0-SNAPSHOT"
+version := "1.0"
 
 scalaVersion := "2.11.6"
+
+description := "Actor service registry for Akka"
 
 lazy val common = Project(id = "common",
                             base = file("common"))
@@ -35,4 +37,43 @@ lazy val root = Project(id = "root",
                             base = file("."))
                             .aggregate(common, serviceRegistry)
 
+publishTo := {
+  val nexus = "https://oss.sonatype.org/"
+  if (isSnapshot.value)
+    Some("snapshots" at nexus + "content/repositories/snapshots")
+  else
+    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+}
 
+
+pomIncludeRepository := { _ => false }
+
+publishArtifact in Test := false
+
+publishMavenStyle := true
+
+
+pomExtra := (
+  <url>https://github.com/Comcast/ActorServiceRegistry</url>
+    <licenses>
+      <license>
+        <name>Apache License, Version 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        <distribution>repo</distribution>
+        <comments>A business-friendly OSS license</comments>
+      </license>
+    </licenses>
+
+    <scm>
+      <url>https://github.com/Comcast/ActorServiceRegistry</url>
+      <connection>https://github.com/Comcast/ActorServiceRegistry.git</connection>
+    </scm>
+    <developers>
+      <developer>
+        <name>David Bolene</name>
+      </developer>
+      <developer>
+        <name>Val Apgar</name>
+        <organization>Comcast</organization>
+      </developer>
+    </developers>)

--- a/common/build.sbt
+++ b/common/build.sbt
@@ -20,7 +20,7 @@ organization := "com.comcast"
 
 name := "actor-service-registry-common"
 
-version := "1.0-SNAPSHOT"
+version := "1.0"
 
 scalaVersion := "2.11.6"
 
@@ -68,3 +68,35 @@ libraryDependencies += "nl.grons" %% "metrics-scala" % "3.3.0_a2.3" excludeAll (
 
 libraryDependencies +=  "joda-time" % "joda-time" % "2.7"
 
+
+pomIncludeRepository := { _ => false }
+
+publishArtifact in Test := false
+
+publishMavenStyle := true
+
+
+pomExtra := (
+  <url>https://github.com/Comcast/ActorServiceRegistry</url>
+    <licenses>
+      <license>
+        <name>Apache License, Version 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        <distribution>repo</distribution>
+        <comments>A business-friendly OSS license</comments>
+      </license>
+    </licenses>
+
+    <scm>
+      <url>https://github.com/Comcast/ActorServiceRegistry</url>
+      <connection>https://github.com/Comcast/ActorServiceRegistry.git</connection>
+    </scm>
+    <developers>
+      <developer>
+        <name>David Bolene</name>
+      </developer>
+      <developer>
+        <name>Val Apgar</name>
+        <organization>Comcast</organization>
+      </developer>
+    </developers>)

--- a/common/project/build.properties
+++ b/common/project/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.5
+sbt.version=0.13.9

--- a/common/src/main/scala/com/comcast/csv/common/ServiceRegistrar.scala
+++ b/common/src/main/scala/com/comcast/csv/common/ServiceRegistrar.scala
@@ -1,0 +1,46 @@
+package com.comcast.csv.common
+
+import akka.actor.{Actor, ActorRef, Props}
+import akka.routing.{RoundRobinRoutingLogic, Router}
+import com.comcast.csv.common.protocol.ServiceProtocol.ServiceNotOnline
+import com.comcast.csv.common.protocol.ServiceRegistryProtocol.{ServiceChanged, SubscribeToService, UnSubscribeToService}
+import org.slf4j.LoggerFactory
+
+
+object ServiceRegistrar {
+  def props(serviceName: String, serviceRegistry: ActorRef): Props =
+    Props(new ServiceRegistrar(serviceName, serviceRegistry))
+}
+
+class ServiceRegistrar(serviceName: String, serviceRegistry: ActorRef) extends Actor {
+
+  val log = LoggerFactory.getLogger(this.getClass)
+
+  var router = Router(RoundRobinRoutingLogic())
+
+  serviceRegistry ! SubscribeToService(serviceName)
+
+  def receive = {
+
+    case serviceChanged: ServiceChanged =>
+      log.info(s"Received ServiceChanged(${serviceChanged.serviceName}, ${serviceChanged.serviceEndpoint}) from $sender")
+
+      router = serviceChanged.serviceEndpoint.foldLeft(Router(RoundRobinRoutingLogic())) {
+        (newRouter, endPoint) =>
+          newRouter.addRoutee(endPoint)
+        }
+
+
+    case x =>
+      if (router.routees.size > 0) {
+        router.route(x, sender())
+      } else {
+        sender() ! ServiceNotOnline(serviceName)
+      }
+  }
+
+  override def postStop(): Unit = {
+    serviceRegistry ! UnSubscribeToService(serviceName)
+    super.postStop()
+  }
+}

--- a/common/src/main/scala/com/comcast/csv/common/protocol/ServiceRegistryProtocol.scala
+++ b/common/src/main/scala/com/comcast/csv/common/protocol/ServiceRegistryProtocol.scala
@@ -31,27 +31,26 @@ object ServiceRegistryProtocol {
   /**
    * Service implementor sends to ServiceRegistry when transitions to offline.
    */
-  case class UnPublishService(serviceName: String)
+  case class UnPublishService(serviceName: String, serviceEndpoint: ActorRef)
   /**
    * Service client sends to ServiceRegistry when requiring dependent service.
    */
   case class SubscribeToService(serviceName: String)
+
   /**
    * Service client sends to ServiceRegistry when no longer requiring dependent service.
    */
   case class UnSubscribeToService(serviceName: String)
-  /**
-   * ServiceRegistry sends to service client when subscribed to service is now online.
-   */
-  case class ServiceAvailable(serviceName: String, serviceEndpoint: ActorRef)
-  /**
-   * ServiceRegistry sends to service client when subscribed to service is now offline.
-   */
-  case class ServiceUnAvailable(serviceName: String)
+
   /**
    * ServiceRegistry sends to publishers and subscribers when ServiceRegistry has been restarted
    *   requiring all participants to re-subscribe and re-publish.
    */
   case class RegistryHasRestarted(registry: ActorRef)
+
+  /**
+   * Message sent whenever an actor has entered or exited the service pool
+   */
+  case class ServiceChanged(serviceName: String, serviceEndpoint: List[ActorRef])
 
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.5
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,3 +23,7 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.1")

--- a/serviceRegistry/build.sbt
+++ b/serviceRegistry/build.sbt
@@ -20,7 +20,7 @@ organization := "com.comcast"
 
 name := "actor-service-registry"
 
-version := "1.0-SNAPSHOT"
+version := "1.0"
 
 scalaVersion := "2.11.6"
 
@@ -75,9 +75,48 @@ libraryDependencies += "nl.grons" %% "metrics-scala" % "3.3.0_a2.3" excludeAll (
 libraryDependencies +=  "joda-time" % "joda-time" % "2.7"
 
 
+val kamonOrg = "io.kamon"
+val kamonVersion = "0.5.2"
+
+libraryDependencies += kamonOrg %% "kamon-core" % kamonVersion
+
+
 artifact in (Compile, assembly) := {
   val art = (artifact in (Compile, assembly)).value
   art.copy(`classifier` = Some("assembly"))
 }
 
 addArtifact(artifact in (Compile, assembly), assembly)
+
+
+pomIncludeRepository := { _ => false }
+
+publishArtifact in Test := false
+
+publishMavenStyle := true
+
+
+pomExtra := (
+  <url>https://github.com/Comcast/ActorServiceRegistry</url>
+    <licenses>
+      <license>
+        <name>Apache License, Version 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        <distribution>repo</distribution>
+        <comments>A business-friendly OSS license</comments>
+      </license>
+    </licenses>
+
+    <scm>
+      <url>https://github.com/Comcast/ActorServiceRegistry</url>
+      <connection>https://github.com/Comcast/ActorServiceRegistry.git</connection>
+    </scm>
+    <developers>
+      <developer>
+        <name>David Bolene</name>
+      </developer>
+      <developer>
+        <name>Val Apgar</name>
+        <organization>Comcast</organization>
+      </developer>
+    </developers>)

--- a/serviceRegistry/project/build.properties
+++ b/serviceRegistry/project/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.5
+sbt.version=0.13.9

--- a/serviceRegistry/src/test/resources/application.conf
+++ b/serviceRegistry/src/test/resources/application.conf
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 akka {
-  loglevel = INFO
+  loglevel = DEBUG
   log-dead-letters = off
 
   actor {

--- a/serviceRegistry/src/test/scala/com/comcast/csv/akka/serviceregistry/ServiceRegistrarTest.scala
+++ b/serviceRegistry/src/test/scala/com/comcast/csv/akka/serviceregistry/ServiceRegistrarTest.scala
@@ -1,0 +1,120 @@
+package com.comcast.csv.akka.serviceregistry
+
+import akka.actor.ActorSystem
+import akka.testkit.{TestProbe, ImplicitSender, TestActorRef, TestKit}
+import com.comcast.csv.akka.serviceregistry.SampleServiceProtocol.{GoOffline, SampleServiceInitialize}
+import com.comcast.csv.common.ServiceRegistrar
+import com.comcast.csv.common.protocol.ServiceProtocol.ServiceNotOnline
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
+
+
+class ServiceRegistrarTest extends TestKit(ActorSystem("test")) with FlatSpecLike with ImplicitSender with BeforeAndAfterAll{
+
+  "The service registrar" must "appropriately route messages to two end points" in {
+    // start the registry
+    val registry = system.actorOf(ServiceRegistry.props)
+
+    // start a sample service
+    val aSampleService = TestActorRef[SampleService]
+    aSampleService ! SampleServiceInitialize(serviceName = "sampleService", registry = registry)
+
+    val aSampleService2 = TestActorRef[SampleService]
+    aSampleService2 ! SampleServiceInitialize(serviceName = "sampleService", registry = registry)
+
+    val registrar = TestActorRef(new ServiceRegistrar("sampleService", registry))
+
+    Thread sleep 100
+
+    registrar ! "echo"
+
+    expectMsg("echo")
+
+
+    registrar ! "echo"
+
+    expectMsg("echo")
+
+    assert(aSampleService.underlyingActor.routedMessageCount == 1)
+    assert(aSampleService2.underlyingActor.routedMessageCount == 1)
+
+  }
+
+  "The service registrar" must "say the service is unavailable when services are unpublished" in {
+    // start the registry
+    val registry = system.actorOf(ServiceRegistry.props)
+
+    // start a sample service
+    val aSampleService = TestActorRef[SampleService]
+    aSampleService ! SampleServiceInitialize(serviceName = "sampleService", registry = registry)
+
+    val aSampleService2 = TestActorRef[SampleService]
+    aSampleService2 ! SampleServiceInitialize(serviceName = "sampleService", registry = registry)
+
+    val registrar = TestActorRef(new ServiceRegistrar("sampleService", registry))
+
+    Thread sleep 100
+
+    registrar ! "echo"
+
+    expectMsg("echo")
+
+
+    registrar ! "echo"
+
+    expectMsg("echo")
+
+    assert(aSampleService.underlyingActor.routedMessageCount == 1)
+    assert(aSampleService2.underlyingActor.routedMessageCount == 1)
+
+    aSampleService ! GoOffline
+    aSampleService2 ! GoOffline
+
+    Thread sleep 100
+
+    registrar ! "echo"
+
+    expectMsg(ServiceNotOnline("sampleService"))
+
+  }
+
+  override def afterAll() = {
+    system.shutdown()
+  }
+
+}
+
+/*
+
+object ServiceRegistrar {
+   def props(serviceName: String, serviceRegistry: ActorRef): Props =
+     Props(new ServiceRegistrar(serviceName, serviceRegistry))
+ }
+
+class ServiceRegistrar(serviceName: String, serviceRegistry: ActorRef) extends Actor {
+
+   var router = Router(RoundRobinRoutingLogic())
+
+   serviceRegistry ! SubscribeToService(serviceName)
+
+   def receive = {
+
+     case serviceChanged: ServiceChanged =>
+       serviceChanged.serviceEndpoint foreach {
+         endpoint =>
+           router = router.addRoutee(endpoint)
+       }
+
+     case x =>
+       if (router.routees.size > 0) {
+         router.route(x, sender())
+       } else {
+         sender() ! ServiceNotOnline(serviceName)
+       }
+   }
+
+   override def postStop(): Unit = {
+     serviceRegistry ! UnSubscribeToService(serviceName)
+     super.postStop()
+   }
+ }
+*/


### PR DESCRIPTION
- Lists of actors at a given service name
- Dynamic Router 'Registrar' that can maintain a router for
  each actor at a given service name end point.
  This effectively provides dynamic service load balancing
  within a cluster, using the Actor Service Registry
